### PR TITLE
Document postgresHost and postgresExternalName

### DIFF
--- a/helm/ffc-demo-payment-service/development-values.yaml
+++ b/helm/ffc-demo-payment-service/development-values.yaml
@@ -3,6 +3,5 @@ container:
   args: ["node index"]
   messageQueueHost: ffc-demo-payment-artemis-activemq-artemis
 postgresHost: ffc-demo-payment-postgres-postgresql
-postgresExternalName:
 service:
   port: 3004

--- a/helm/ffc-demo-payment-service/values.yaml
+++ b/helm/ffc-demo-payment-service/values.yaml
@@ -7,7 +7,7 @@ postgresHost: ffc-demo-payments-postgres
 # postgresExternalName is the external host name to which PostgreSQL
 # requests should be forwarded. If empty, PostgreSQL is assumed to be
 # within the cluster and accessible via postgresHost
-postgresExternalName: host.docker.internal
+postgresExternalName:
 postgresPort: 5432
 name: ffc-demo-payment-service
 image: ffc-demo-payment-service

--- a/helm/ffc-demo-payment-service/values.yaml
+++ b/helm/ffc-demo-payment-service/values.yaml
@@ -2,7 +2,11 @@ environment: development
 postgresUsername: postgres@mine-support2
 postgresPassword: changeme
 postgresDatabase: mine_payments
+# postgresHost is the host name of the PostgreSQL service
 postgresHost: ffc-demo-payments-postgres
+# postgresExternalName is the external host name to which PostgreSQL
+# requests should be forwarded. If empty, PostgreSQL is assumed to be
+# within the cluster and accessible via postgresHost
 postgresExternalName: host.docker.internal
 postgresPort: 5432
 name: ffc-demo-payment-service


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-227

These two variables have caused confusion. Values should be documented
in values.yaml, as per official Helm best practices.