### PR TITLE
PSD-529 Update kubernetes resources to specify namespace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-library@2.0.0')
+@Library('defra-library@3.0.0')
 import uk.gov.defra.ffc.DefraUtils
 def defraUtils = new DefraUtils()
 

--- a/helm/ffc-demo-payment-service/jenkins-aws.yaml
+++ b/helm/ffc-demo-payment-service/jenkins-aws.yaml
@@ -1,4 +1,5 @@
 name: ffc-demo-payment-service
+namespace: ffc-demo
 environment: production
 imagePullSecret: myregistrykey
 container:

--- a/helm/ffc-demo-payment-service/templates/deployment.yaml
+++ b/helm/ffc-demo-payment-service/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         redeployOnChange: {{ quote .Values.container.redeployOnChange }}
     spec:
+      priorityClassName: {{ quote .Values.container.priorityClassName }}
       restartPolicy: {{ quote .Values.container.restartPolicy }}
       {{- if .Values.imagePullSecret }}
       imagePullSecrets:

--- a/helm/ffc-demo-payment-service/templates/deployment.yaml
+++ b/helm/ffc-demo-payment-service/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: {{ quote .Values.name }}
     environment: {{ quote .Values.environment }}
+  namespace: {{ quote .Values.namespace }}
 spec:
   replicas: {{ .Values.replicaCount }}
   minReadySeconds: {{ .Values.minReadySeconds }}

--- a/helm/ffc-demo-payment-service/templates/service.yaml
+++ b/helm/ffc-demo-payment-service/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Values.postgresHost }}
   labels:
     environment: {{ quote .Values.environment }}
+  namespace: {{ .Values.namespace }}
 spec:
   type: ExternalName
   externalName: {{ quote .Values.postgresExternalName }}

--- a/helm/ffc-demo-payment-service/templates/service.yaml
+++ b/helm/ffc-demo-payment-service/templates/service.yaml
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ quote .Values.name }}
+  namespace: {{ quote .Values.namespace }}
   labels:
     app: {{ quote .Values.name }}
     environment: {{ quote .Values.environment }}

--- a/helm/ffc-demo-payment-service/values.yaml
+++ b/helm/ffc-demo-payment-service/values.yaml
@@ -10,6 +10,7 @@ postgresHost: ffc-demo-payments-postgres
 postgresExternalName:
 postgresPort: 5432
 name: ffc-demo-payment-service
+namespace: ffc-demo
 image: ffc-demo-payment-service
 imagePullSecret:
 service:

--- a/helm/ffc-demo-payment-service/values.yaml
+++ b/helm/ffc-demo-payment-service/values.yaml
@@ -19,6 +19,7 @@ container:
   port: 3004
   registry:
   tag: latest
+  priorityClassName: low
   imagePullPolicy: IfNotPresent
   requestMemory: 60Mi
   requestCpu: 40m

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-demo-payment-service",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-demo-payment-service",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-529

Updating kubernetes resources to specify namespace, as Helm 3
doesn't have the --namespace switch in the upgrade command