### PR TITLE
Container port missing name of http

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Additional Docker Compose files are provided for scenarios such as linking to ot
 
 Link to other services and expose inspection SQS and Postgres ports:
 * `docker network create ffc-demo`
-* `docker-compose -f docker-compose.yaml -f docker-compose.link.yaml docker-compose.override.yaml up`
+* `docker-compose -f docker-compose.yaml -f docker-compose.link.yaml -f docker-compose.override.yaml up`
 
 ### Test the service
 

--- a/helm/ffc-demo-payment-service/templates/deployment.yaml
+++ b/helm/ffc-demo-payment-service/templates/deployment.yaml
@@ -78,7 +78,9 @@ spec:
         - name: PORT
           value: {{ quote .Values.container.port }}
         ports:
-        - containerPort: {{ .Values.container.port }}
+        - name: http
+          containerPort: {{ .Values.container.port }}
+          protocol: TCP
         resources:
           requests:
             memory: {{ quote .Values.container.requestMemory }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-demo-payment-service",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-666

The payment site cannot access the payment service as the API is not
available within the cluster due to missing configuration in the
deployment file.

This PR adds the missing name annotation on the container port