### PR TITLE
Ensure health check endpoint contain error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-demo-payment-service",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server/routes/healthy.js
+++ b/server/routes/healthy.js
@@ -1,15 +1,22 @@
 const databaseService = require('../services/database-service')
-const messageService = require('../services/message-service')
+
+const SERVICE_UNAVAILABLE = 503
+const OK = 200
 
 module.exports = {
   method: 'GET',
   path: '/healthy',
   options: {
     handler: async (request, h) => {
-      if (await databaseService.isConnected() && messageService.isRunning()) {
-        return h.response('ok').code(200)
+      try {
+        if (await databaseService.isConnected()) {
+          return h.response('ok').code(OK)
+        }
+        return h.response('service unavailable').code(SERVICE_UNAVAILABLE)
+      } catch (ex) {
+        console.error('error running healthy check', ex)
+        return h.response(`error running healthy check: ${ex.message}`).code(SERVICE_UNAVAILABLE)
       }
-      return h.response('services unavailable').code(500)
     }
   }
 }

--- a/test/integration/local/services/message-base.test.js
+++ b/test/integration/local/services/message-base.test.js
@@ -4,23 +4,19 @@ const config = require('../../../../server/config')
 
 const consoleErrorOrig = console.consoleError
 
-let mockConsoleError
 let messageBase
 
 describe('message base', () => {
   beforeAll(() => {
-    mockConsoleError = jest.fn()
-    console.error = mockConsoleError
+    console.error = jest.fn()
   })
+
   afterAll(() => {
     console.error = consoleErrorOrig
   })
-  beforeEach(() => {
-    mockConsoleError.mockClear()
-  })
+
   afterEach(async () => {
     await messageBase.closeConnection()
-    messageBase = undefined
   })
 
   test('open connection error is logged with name then rethrown', async () => {
@@ -34,10 +30,8 @@ describe('message base', () => {
       ex = err
     }
     expect(ex.message).toContain('Failed to authenticate')
+    expect(console.error).toHaveBeenCalledTimes(1)
 
-    expect(mockConsoleError.mock.calls.length).toEqual(1)
-    const call1 = mockConsoleError.mock.calls[0]
-    expect(call1[0]).toEqual(`error opening ${name} connection`)
-    expect(call1[1]).toEqual(ex)
+    expect(console.error).toHaveBeenCalledWith(`error opening ${name} connection`, ex)
   })
 })

--- a/test/integration/narrow/routes/payment.test.js
+++ b/test/integration/narrow/routes/payment.test.js
@@ -39,7 +39,7 @@ describe('Payment test', () => {
         }
       ]
     }
-    paymentService.getAll = jest.fn(() => expectedPayload)
+    paymentService.getAll.mockReturnValue(expectedPayload)
 
     const response = await server.inject(options)
     expect(response.statusCode).toBe(200)

--- a/test/unit/routes/payment-handler.test.js
+++ b/test/unit/routes/payment-handler.test.js
@@ -20,7 +20,7 @@ describe('payment handler', () => {
       ]
     }
 
-    paymentService.getById = jest.fn().mockReturnValue(validPaymentResult)
+    paymentService.getById.mockReturnValue(validPaymentResult)
     // act
     const request = { params: { id: 'claim001' } }
     await paymentHandler.getPayment(request, h)
@@ -49,7 +49,7 @@ describe('payment handler', () => {
         schedule: []
       }]
 
-    paymentService.getAll = jest.fn().mockReturnValue(validPaymentResults)
+    paymentService.getAll.mockReturnValue(validPaymentResults)
     // act
     const request = {}
     await paymentHandler.getPayments(request, h)

--- a/test/unit/routes/schedule-handler.test.js
+++ b/test/unit/routes/schedule-handler.test.js
@@ -9,7 +9,7 @@ describe('schedule handler', () => {
     // arrange
     const h = new MockHapiH()
     const noClaimResult = []
-    scheduleService.getById = jest.fn().mockReturnValueOnce(noClaimResult)
+    scheduleService.getById.mockReturnValueOnce(noClaimResult)
     // act
     const request = { params: { id: 'noSuchClaim' } }
     await scheduleHandler.getClaim(request, h)
@@ -28,7 +28,7 @@ describe('schedule handler', () => {
         paymentAmount: '190.96'
       }
     ]
-    scheduleService.getById = jest.fn().mockReturnValueOnce(validClaimResult)
+    scheduleService.getById.mockReturnValueOnce(validClaimResult)
     // act
     const request = { params: { id: 'claim001' } }
     await scheduleHandler.getClaim(request, h)
@@ -52,7 +52,7 @@ describe('schedule handler', () => {
         paymentAmount: '190.96'
       }
     ]
-    scheduleService.getAll = jest.fn().mockReturnValueOnce(validClaimResult)
+    scheduleService.getAll.mockReturnValueOnce(validClaimResult)
     // act
     const request = { }
     await scheduleHandler.getClaims(request, h)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-318

Uncaught errors in the health check endpoint can make it difficult to
see what is unhealthy. The end point should handle the error and provide
details, along with the error message